### PR TITLE
Expose more OPC internals

### DIFF
--- a/message.go
+++ b/message.go
@@ -1,80 +1,81 @@
 package opc
 
+// OPC constants.
 const (
-	SET_PIXEL_COLORS  = 0x00
-	SYSTEM_EXCLUSIVE  = 0xFF
-	HEADER_BYTES      = 4
-	BROADCAST_CHANNEL = 0
-	MAX_MESSAGE_SIZE  = 0xFFFF
+	SetPixelColorsCmd  = 0x00   // SetPixelColorsCmd is the command for setting pixelcolor.
+	SystemExclusiveCmd = 0xFF   // SystemExclusiveCmd is denotes a command for a specific system.
+	HeaderBytes        = 4      // HeaderBytes is the number of bytes an OPC header consists of.
+	BroadcastChannel   = 0      // BroadcastChannel is the broadcast channel number.
+	MaxMessageSize     = 0xFFFF // MaxMessageSize is the max message size for the OPC protocol.
 )
 
-// This struct describes a single message
+// Message describes a single message
 // that follows the OPC protocol
 type Message struct {
-	channel byte
-	command byte
-	highLen byte
-	lowLen  byte
-	data    []byte
+	Channel byte
+	Command byte
+	HighLen byte
+	LowLen  byte
+	Data    []byte
 }
 
-// Creates and returns a pointer to a new message that is to be sent
+// NewMessage creates and returns a pointer to a new message that is to be sent
 // to the passed in channel
 func NewMessage(channel uint8) *Message {
-	return &Message{channel: channel, data: make([]byte, MAX_MESSAGE_SIZE)}
+	return &Message{Channel: channel, Data: make([]byte, MaxMessageSize)}
 }
 
-// Sets the pixel color of the passed in pixel
+// SetPixelColor sets the pixel color of the passed in pixel
 // to the passed in red, green, and blue colors, respectively for this message
 func (m *Message) SetPixelColor(pixel int, r uint8, g uint8, b uint8) {
 	index := (3 * pixel)
-	m.data[index] = r
-	m.data[index+1] = g
-	m.data[index+2] = b
+	m.Data[index] = r
+	m.Data[index+1] = g
+	m.Data[index+2] = b
 }
 
-// Specifies that this message is a System Exclusive Message
+// SystemExclusive specifies that this message is a System Exclusive Message
 // and populates data accordingly
-func (m *Message) SystemExclusive(systemId []byte, data []byte) {
-	m.command = SYSTEM_EXCLUSIVE
-	m.data = systemId
+func (m *Message) SystemExclusive(systemID []byte, data []byte) {
+	m.Command = SystemExclusiveCmd
+	m.Data = systemID
 	for i := 0; i < len(data); i++ {
-		m.data = append(m.data, data[i])
+		m.Data = append(m.Data, data[i])
 	}
 }
 
-// Sets the length of this message by splitting
+// SetLength sets the length of this message by splitting
 // the passed in length into high and low length bytes.
 func (m *Message) SetLength(length uint16) {
-	m.highLen = byte(length >> 8)
-	m.lowLen = byte(length)
+	m.HighLen = byte(length >> 8)
+	m.LowLen = byte(length)
 }
 
-// Returns the length of the message.
+// Length returns the length of the message.
 // The length of the message is respresented by combining
 // the high and low length bytes of this message.
 func (m *Message) Length() uint16 {
-	return (uint16(m.highLen) << 8) | uint16(m.lowLen)
+	return (uint16(m.HighLen) << 8) | uint16(m.LowLen)
 }
 
 // Returns whether or not this message is valid or not.
 // Validity is determined as whether or not the Length of the message
 // corresponds with the number of data bytes in the message
 func (m *Message) IsValid() bool {
-	return m.Length() == uint16(len(m.data))
+	return m.Length() == uint16(len(m.Data))
 }
 
 // Returns whether or not this message is a Broadcast message.
 func (m *Message) IsBroadcast() bool {
-	return m.channel == BROADCAST_CHANNEL
+	return m.Channel == BroadcastChannel
 }
 
-// Returns a byte array representation of this message.
+// ByteArray returns a byte array representation of this message.
 func (m *Message) ByteArray() []byte {
 	data := []byte{}
-	data = append(data, m.channel, m.command, m.highLen, m.lowLen)
+	data = append(data, m.Channel, m.Command, m.HighLen, m.LowLen)
 	for i := uint16(0); i < m.Length(); i++ {
-		data = append(data, m.data[i])
+		data = append(data, m.Data[i])
 	}
 	return data
 }

--- a/message_test.go
+++ b/message_test.go
@@ -8,19 +8,19 @@ import (
 func TestNewMessage(t *testing.T) {
 	m := NewMessage(0)
 
-	if m.channel != 0 {
+	if m.Channel != 0 {
 		t.Errorf("Unexpected channel value after initialization.")
 	}
 
-	if m.command != SET_PIXEL_COLORS {
+	if m.Command != SetPixelColorsCmd {
 		t.Errorf("Unexpected command value after initialization.")
 	}
 
-	if m.highLen != 0 {
+	if m.HighLen != 0 {
 		t.Errorf("Unexpected high length byte value after initialization.")
 	}
 
-	if m.lowLen != 0 {
+	if m.LowLen != 0 {
 		t.Errorf("Unexpected low length byte value after initialization.")
 	}
 }
@@ -29,15 +29,15 @@ func TestSetPixelColor(t *testing.T) {
 	m := NewMessage(0)
 	m.SetPixelColor(0, uint8(255), uint8(254), uint8(253))
 
-	if m.data[0] != 255 {
+	if m.Data[0] != 255 {
 		t.Errorf("Did not set pixel 0's Red value correctly")
 	}
 
-	if m.data[1] != 254 {
+	if m.Data[1] != 254 {
 		t.Errorf("Did not set pixel 0's Green value correctly")
 	}
 
-	if m.data[2] != 253 {
+	if m.Data[2] != 253 {
 		t.Errorf("Did not set pixel 0's Blue value correctly")
 	}
 }
@@ -45,19 +45,19 @@ func TestSetPixelColor(t *testing.T) {
 func TestSetLength(t *testing.T) {
 	m := NewMessage(0)
 	m.SetLength(10)
-	if uint64(m.lowLen) != uint64(10) {
+	if uint64(m.LowLen) != uint64(10) {
 		t.Errorf("Expected a call to SetLength() to set the Message length to 10.")
 	}
 
-	m.SetLength(uint16(MAX_MESSAGE_SIZE))
-	if m.Length() != uint16(MAX_MESSAGE_SIZE) {
+	m.SetLength(uint16(MaxMessageSize))
+	if m.Length() != uint16(MaxMessageSize) {
 		t.Errorf("Expected setting length to MAX_MESSAGE_SIZE to be reflected correctly.")
 	}
 }
 
 func TestLength(t *testing.T) {
 	m := NewMessage(0)
-	m.lowLen = byte(10)
+	m.LowLen = byte(10)
 	v := m.Length()
 	if v != uint16(10) {
 		t.Errorf("Expected a call to Length() to return 10 after manually setting it to 10.")
@@ -70,7 +70,7 @@ func TestIsValid(t *testing.T) {
 		t.Errorf("A Message should not be valid after initializing it.")
 	}
 
-	m.data = make([]byte, 9)
+	m.Data = make([]byte, 9)
 	m.SetLength(9)
 
 	if !m.IsValid() {
@@ -84,7 +84,7 @@ func TestIsBroadcast(t *testing.T) {
 		t.Errorf("A Message with a channel set to 255 should not be a Broadcast.")
 	}
 
-	m.channel = byte(0)
+	m.Channel = byte(0)
 	if !m.IsBroadcast() {
 		t.Errorf("A Message with a channel set to 0 should be a Broadcast.")
 	}

--- a/opc.go
+++ b/opc.go
@@ -1,12 +1,14 @@
 package opc
 
 const (
-	DEFAULT_OPC_PORT = "7890"
+	// DefaultOpcPort is the default Open Pixel Control protocol port.
+	DefaultOpcPort = "7890"
 )
 
+// ListenAndServe creates a new OPC server and listens indefinently.
 func ListenAndServe() {
 	s := NewServer()
-	go s.ListenOnPort("tcp", DEFAULT_OPC_PORT)
+	go s.ListenOnPort("tcp", DefaultOpcPort)
 	go s.Process()
 	select {}
 }

--- a/server.go
+++ b/server.go
@@ -5,7 +5,7 @@ import (
 	"net"
 )
 
-// This struct describes an OPC server,
+// Server describes an OPC server,
 // which keeps track of all connected OPC devices
 // as well as a channel of incoming messages from all connected clients
 type Server struct {
@@ -13,23 +13,23 @@ type Server struct {
 	messages chan *Message
 }
 
-// Creates and returns a new opc.Server.
+// NewServer creates and returns a new opc.Server.
 // Accepts a list of usb product IDs in which to send opc messages to.
 func NewServer() *Server {
 	return &Server{devs: make(map[uint8]Device), messages: make(chan *Message)}
 }
 
-// Registers the passed in device to the OPC server
+// RegisterDevice registers the passed in device to the OPC server
 func (s *Server) RegisterDevice(dev Device) {
 	s.devs[dev.Channel()] = dev
 }
 
-// Unregisters the passed in device from the OPC server
+// UnregisterDevice unregisters the passed in device from the OPC server
 func (s *Server) UnregisterDevice(dev Device) {
 	delete(s.devs, dev.Channel())
 }
 
-// Listens on the passed in port with the passed in protocol,
+// ListenOnPort listens on the passed in port with the passed in protocol,
 // which in turn accepts incoming connections and handles them
 // by issuing individual goroutines.
 func (s *Server) ListenOnPort(protocol string, port string) {
@@ -44,22 +44,22 @@ func (s *Server) ListenOnPort(protocol string, port string) {
 			panic(connErr)
 		}
 
-		go s.handleConn(conn)
+		go s.HandleConn(conn)
 	}
 }
 
-// Reads off OPC messages from the passed in connection
+// HandleConn reads off OPC messages from the passed in connection
 // until the connection breaks.
-// Appends all valid messages onto the message channel
-func (s *Server) handleConn(conn net.Conn) {
+// Appends all valid messages onto the message channel.
+// ListenOnPort will accept clients and pass the processing on to
+// this function.
+func (s *Server) HandleConn(conn net.Conn) {
+	defer conn.Close()
 	for {
-		msg, err := s.readOpc(conn)
+		msg, err := ReadOpc(conn)
 		if err != nil {
 			// If we encounter an error reading from the connection,
 			// "break" out of the loop and stop reading.
-			//
-			// TODO find some way of maybe alerting to the client
-			//      that an error occured
 			break
 		}
 
@@ -67,8 +67,8 @@ func (s *Server) handleConn(conn net.Conn) {
 	}
 }
 
-// Reads and returns a single OPC message from the passed in connection.
-func (s *Server) readOpc(conn net.Conn) (*Message, error) {
+// ReadOpc reads and returns a single OPC message from the passed in connection.
+func ReadOpc(conn net.Conn) (*Message, error) {
 	buf := make([]byte, 1)
 	bytesRead := uint16(0)
 	m := NewMessage(0)
@@ -106,10 +106,13 @@ func (s *Server) readOpc(conn net.Conn) (*Message, error) {
 	return m, nil
 }
 
-// Dispatches the passed in message to all applicable devices.
+// Dispatch dispatches the passed in message to all applicable devices.
 // If the message is of a Broadcast type, it sends it to all connected devices
 // Otherwise, it sends it to the specified device.
-func (s *Server) dispatch(m *Message) {
+// You can use Process to let the server automatically call this Dispatch for
+// each incoming message. Or listen to the Messages channel on Server yourself
+// and Dispatch it yourself.
+func (s *Server) Dispatch(m *Message) {
 	if m.IsBroadcast() {
 		// Broadcast the message to all registered devices
 		for i := range s.devs {
@@ -123,10 +126,10 @@ func (s *Server) dispatch(m *Message) {
 	}
 }
 
-// Processes all pending messages indefinitely
+// Process processes all pending messages indefinitely.
 func (s *Server) Process() {
 	for {
 		msg := <-s.messages
-		s.dispatch(msg)
+		s.Dispatch(msg)
 	}
 }

--- a/server.go
+++ b/server.go
@@ -8,24 +8,24 @@ import (
 // which keeps track of all connected OPC devices
 // as well as a channel of incoming messages from all connected clients
 type Server struct {
-	devs     map[uint8]Device
-	messages chan *Message
+	Devs     map[uint8]Device
+	Messages chan *Message
 }
 
 // NewServer creates and returns a new opc.Server.
 // Accepts a list of usb product IDs in which to send opc messages to.
 func NewServer() *Server {
-	return &Server{devs: make(map[uint8]Device), messages: make(chan *Message)}
+	return &Server{Devs: make(map[uint8]Device), Messages: make(chan *Message)}
 }
 
 // RegisterDevice registers the passed in device to the OPC server
 func (s *Server) RegisterDevice(dev Device) {
-	s.devs[dev.Channel()] = dev
+	s.Devs[dev.Channel()] = dev
 }
 
 // UnregisterDevice unregisters the passed in device from the OPC server
 func (s *Server) UnregisterDevice(dev Device) {
-	delete(s.devs, dev.Channel())
+	delete(s.Devs, dev.Channel())
 }
 
 // ListenOnPort listens on the passed in port with the passed in protocol,
@@ -62,7 +62,7 @@ func (s *Server) HandleConn(conn net.Conn) {
 			break
 		}
 
-		s.messages <- msg
+		s.Messages <- msg
 	}
 }
 
@@ -114,20 +114,20 @@ func ReadOpc(conn net.Conn) (*Message, error) {
 func (s *Server) Dispatch(m *Message) {
 	if m.IsBroadcast() {
 		// Broadcast the message to all registered devices
-		for i := range s.devs {
-			s.devs[i].Write(m)
+		for i := range s.Devs {
+			s.Devs[i].Write(m)
 		}
 
 	} else {
 		// Otherwise write to the device specified by the message's channel
-		s.devs[m.channel].Write(m)
+		s.Devs[m.channel].Write(m)
 	}
 }
 
 // Process processes all pending messages indefinitely.
 func (s *Server) Process() {
 	for {
-		msg := <-s.messages
+		msg := <-s.Messages
 		s.Dispatch(msg)
 	}
 }

--- a/server.go
+++ b/server.go
@@ -1,7 +1,6 @@
 package opc
 
 import (
-	_ "fmt"
 	"net"
 )
 
@@ -121,7 +120,6 @@ func (s *Server) Dispatch(m *Message) {
 
 	} else {
 		// Otherwise write to the device specified by the message's channel
-		//fmt.Printf("Attempting to write to device at channel:%d\n", m.channel)
 		s.devs[m.channel].Write(m)
 	}
 }

--- a/server.go
+++ b/server.go
@@ -10,6 +10,7 @@ import (
 type Server struct {
 	Devs     map[uint8]Device
 	Messages chan *Message
+	Listener net.Listener
 }
 
 // NewServer creates and returns a new opc.Server.
@@ -36,6 +37,8 @@ func (s *Server) ListenOnPort(protocol string, port string) {
 	if listenerErr != nil {
 		panic(listenerErr)
 	}
+
+	s.Listener = listener
 
 	for {
 		conn, connErr := listener.Accept()

--- a/server.go
+++ b/server.go
@@ -86,18 +86,18 @@ func ReadOpc(conn net.Conn) (*Message, error) {
 		// Ignore first 4 bytes to account for HEADER_BYTES
 		switch bytesRead {
 		case 1:
-			m.channel = buf[0]
+			m.Channel = buf[0]
 		case 2:
-			m.command = buf[0]
+			m.Command = buf[0]
 		case 3:
-			m.highLen = buf[0]
+			m.HighLen = buf[0]
 		case 4:
-			m.lowLen = buf[0]
+			m.LowLen = buf[0]
 		default:
-			m.data[bytesRead-5] = buf[0]
+			m.Data[bytesRead-5] = buf[0]
 
 			if bytesRead-4 == m.Length() {
-				m.data = m.data[:m.Length()]
+				m.Data = m.Data[:m.Length()]
 			}
 		}
 	}
@@ -120,7 +120,7 @@ func (s *Server) Dispatch(m *Message) {
 
 	} else {
 		// Otherwise write to the device specified by the message's channel
-		s.Devs[m.channel].Write(m)
+		s.Devs[m.Channel].Write(m)
 	}
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -48,7 +48,7 @@ func TestRegisterDevice(t *testing.T) {
 	d := &MockDevice{channel: 1}
 	s.RegisterDevice(d)
 
-	if _, ok := s.devs[d.Channel()]; !ok {
+	if _, ok := s.Devs[d.Channel()]; !ok {
 		t.Errorf("Expected Device to be registered")
 	}
 }
@@ -59,7 +59,7 @@ func TestUnregisterDevice(t *testing.T) {
 	s.RegisterDevice(d)
 	s.UnregisterDevice(d)
 
-	if _, ok := s.devs[d.Channel()]; ok {
+	if _, ok := s.Devs[d.Channel()]; ok {
 		t.Errorf("Expected Device to be unregistered after registering it")
 	}
 }

--- a/server_test.go
+++ b/server_test.go
@@ -65,12 +65,10 @@ func TestUnregisterDevice(t *testing.T) {
 }
 
 func TestReadOpc(t *testing.T) {
-	s := NewServer()
-
 	payload := []byte{255, 0, 0, 3, 1, 2, 3}
 	m := &MockConn{payload: payload}
 
-	msg, err := s.readOpc(m)
+	msg, err := ReadOpc(m)
 	if err != nil {
 		t.Errorf("Encountered an error when reading a valid Message")
 	}


### PR DESCRIPTION
Hello,

Nice implementation of OPC. However I quickly realised that I can't use it as is, since it is tailored quite specifically to one use case.

I wanted to write an OPC proxy, and that means I need raw access to the `Message` struct and so on. But as the current design is these are not exposed.

I did some changes to the library that allows me to just use some parts, and implement the connection/listening and so exactly as I want to.

This is my first attempt at a Golang project so I can't say I'm an expert. **I'm totally open to modifying this PR if you want that, since I'm aware these break backwards compatability**.

Some notable changes:

1.  Made **ReadOpc** a standalone function. It did not use any of the state in the `Server` struct anyway. And this makes it possible to reuse in other code without being forced to use `Server`.
```
func ReadOpc(conn net.Conn) (*Message, error)
```

2. I made all fields in the `Message` struct exported. When I'm writing my proxy the `Device` concept does not really work, I just want to get the raw messages and send them on, and be able to check the channel and such for each message.

3. Renamed constants and changed comments to follow the "go standard" better. Examples:
```
SET_PIXEL_COLORS -> SetPixelColorsCmd
```
(Coming from C I kind of prefer your way as a matter of taste, but keeping to a language standard if there is such a clear one trumps that my personal taste any day).

Comments in Go should be of the form:
```
Something performs various actions
func Something()
```
Rather than:
```
This performs various actions
func Something()
```
This is from `go vet` suggestions.

---

Anyway, what I ended up using of this is the changes to the exposed fields in `Message` as well as making `ReadOpc` a function that can be used standalone. So if you want me to modify the PR to only include those changes I can do that.